### PR TITLE
fix(markdown-preview): added `ft` and `lazy` to `markdown-preview.nvim` plugin in `lazy.nvim` table

### DIFF
--- a/lua/nn/plugins.lua
+++ b/lua/nn/plugins.lua
@@ -122,6 +122,8 @@ lazy.setup({
 	-- Markdown preview
 	{
 		"iamcco/markdown-preview.nvim",
+		ft = "markdown",
+		lazy = true,
 		build = function()
 			vim.fn["mkdp#util#install"]()
 		end,


### PR DESCRIPTION
## Purpose

> `markdown-preview.nvim` is not working.

## Solution Approach

> Add `ft` and `lazy` to `markdown-preview.nvim` plugin in `lazy.nvim` plugins table.
